### PR TITLE
fix(strict): add use strict to index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const fsp = require('fs-promise');
 
 const newLineCharacters = ["\n", "\r"]


### PR DESCRIPTION
no issue
- in node v4 requiring this library throws an error because `const` and `let` aren't allowed outside of strict mode